### PR TITLE
Add support for 9p mounts in netboot

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,7 @@ netboot_DEPENDENCIES    = $(LDADD_$(rtems_bsp))
 
 CLEANFILES              = $(execimg_SCRIPTS) linkmap
 
-netboot_LDADD          += -ltecla_r $(NFSLIB)
+netboot_LDADD          += -ltecla_r -lt9p $(NFSLIB)
 #AM_LDFLAGS             += -L../cexp/libtecla -L../rtemsNfs/src -L../rtemsNfs/proto
 
 AM_CPPFLAGS            += -DWINS_LINE_DISC 

--- a/netboot.c
+++ b/netboot.c
@@ -142,7 +142,10 @@ select(int  n,  fd_set  *readfds,  fd_set  *writefds, fd_set *exceptfds, struct 
 #ifndef COREDUMP_APP
 
 /* NETBOOT configuration */
-#define CONFIGURE_MAXIMUM_SEMAPHORES   	20 
+#define CONFIGURE_MAXIMUM_SEMAPHORES   	20
+#define CONFIGURE_MAXIMUM_POSIX_MUTEXES 16
+#define CONFIGURE_MAXIMUM_POSIX_CONDITION_VARIABLES 16 /* Depends on maxfids=16 in pathcheck.c */
+#define CONFIGURE_MAXIMUM_POSIX_THREADS 4
 #define CONFIGURE_MAXIMUM_TASKS         10
 #if !ISMINVERSION(4,9,0)
 #define CONFIGURE_MAXIMUM_DEVICES       4
@@ -962,6 +965,8 @@ rtems_task Init(
   unsigned char	ch;
   int	secs;
 
+	t9p_rtems_register();
+
 #ifndef USE_READLINE
 	ansiTiocGwinszInstall(7);
 #endif
@@ -990,7 +995,8 @@ rtems_task Init(
 #else
 	fprintf(stderr,"\n\nRTEMS coredump helper by Till Straumann <strauman@slac.stanford.edu>\n");
 #endif
-	fprintf(stderr,"GIT revision: %s\n", PACKAGE_VERSION);
+	fprintf(stderr, "Build date: %s %s\n", __DATE__, __TIME__);
+	fprintf(stderr, "GIT revision: %s\n", PACKAGE_VERSION);
 
 #ifndef NVRAM_NONE
 	if (!readNVRAM(&ctx)) {

--- a/netboot.c
+++ b/netboot.c
@@ -834,12 +834,12 @@ int  i;
 			} while ( -10 == (fd = isRshPath(&boot_srvname, boot_filename, &errfd, 0)) );
 		} else {
 			releaseMount( 0 );
-		 	if ( (fd = isNfsPath(&boot_srvname, boot_filename, &errfd, 0, 0)) < -10 ) {
+		 	if ( (fd = isRemotePath(&boot_srvname, boot_filename, &errfd, 0, 0, pathType(boot_filename))) < -10 ) {
 				if ( -2 == fd ) {
 					/* not strictly necessary here - just to remind us that
 					 * the file couldn't be opened but the mount was OK
 					 */
-					fprintf(stderr,"NFS mount OK but file couldn't be opened\n");
+					fprintf(stderr,"Remote (NFS or 9P) mount OK but file couldn't be opened\n");
 					releaseMount( 0 );
 				}
 				fd = isTftpPath(&boot_srvname, boot_filename, &errfd, 0);


### PR DESCRIPTION
Tested on ioc-b084-rf02. Works well.

